### PR TITLE
Telescope ui select compatibility

### DIFF
--- a/lua/smuggler/protocol.lua
+++ b/lua/smuggler/protocol.lua
@@ -24,15 +24,20 @@ function M.getavailablesockets()
   return res
 end
 
-function M.choosesocket()
+function M.choosesocket(settings)
   local sockets = M.getavailablesockets()
   local choice = nil
+  local buf = vim.api.nvim_get_current_buf()
   vim.ui.select(sockets, {
     prompt = 'Select a socket:',
   }, function(c)
-    choice = c
+      socket_path = c
+    if socket_path == nil then
+      return -1
+    end
+    nio.run(function() M.runclient(buf, socket_path) end)
+    M.configure_session(settings)
   end)
-  return choice
 end
 
 function M.serialize_requests(handle, queue)
@@ -151,12 +156,7 @@ function M.bufconfig(bufnbr, force, settings)
     end
   end
 
-  local socket_path = M.choosesocket()
-  if socket_path == nil then
-    return -1
-  end
-  nio.run(function() M.runclient(vim.api.nvim_get_current_buf(), socket_path) end)
-  M.configure_session(settings)
+  M.choosesocket(settings)
   return 0
 end
 


### PR DESCRIPTION
telescope_ui_select is nice
https://github.com/nvim-telescope/telescope-ui-select.nvim

one can run :SmuggleConfig and type a few letters of the socket name and quickly select the right socket.

However right now selecting sockets with telescope-ui-select will fail , 

This is because the `on_choice` function in this line https://github.com/Klafyvel/nvim-smuggler/blob/83338211f7c438f4c153d9023d9df1388677db15/lua/smuggler/protocol.lua#L27-L36 

 gets schedule_wraped in telescope-ui-select https://github.com/nvim-telescope/telescope-ui-select.nvim/blob/6e51d7da30bd139a6950adf2a47fda6df9fa06d2/lua/telescope/_extensions/ui-select.lua#L96 
 
Following this when run_client is called here https://github.com/Klafyvel/nvim-smuggler/blob/83338211f7c438f4c153d9023d9df1388677db15/lua/smuggler/protocol.lua#L158, the socket path is `nil`.

i've rearranged things a bit so that the socket is selected , client is run and session is all configured in one go inside `choosesocket`.

this allows telescope-ui-select to work.


the catch is when :Smuggle is called without a configured smuggler this seems to not error and not prompt for smugglers as it currently does.
any ideas on how to get around this ?