### PR TITLE
Autocmd fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ values):
         display_images = true, -- Display images if `images.nvim` is present.
         images_height = 10, -- Number of lines an image should occupy.
         eval_sign_text = "│", -- Symbol in signcolumn to mark evaluated/invalidated , set to "" to disable
+        show_eval = true, -- If set to false, do not attempt to track modifications in evaluated code chunks.
     },
     log = {
         level = "warn", -- available: trace, debug, info, warn, error, fatal

--- a/doc/smuggler.txt
+++ b/doc/smuggler.txt
@@ -185,6 +185,7 @@ values): >
         display_images = true, -- Display images if `images.nvim` is present.
         images_height = 10, -- Number of lines an image should occupy.
         eval_sign_text = "│", -- Symbol in signcolumn to mark evaluated/invalidated , set to "" to disable
+        show_eval = true, -- If set to false, do not attempt to track modifications in evaluated code chunks.
     },
     log = {
         level = "warn", -- available: trace, debug, info, warn, error, fatal

--- a/lua/smuggler/buffers.lua
+++ b/lua/smuggler/buffers.lua
@@ -99,6 +99,7 @@ function M.buffer(bufnbr, force, settings)
         chunks_shown = true,
         results_shown = true,
         diagnostics_shown = true,
+        aucommands = {},
 	}
     run.buffers[bufnbr] = buffer
 	M.choosesocket(buffer)

--- a/lua/smuggler/config.lua
+++ b/lua/smuggler/config.lua
@@ -11,6 +11,7 @@ config.ui = {
     mappings = {}, -- Default mappings are defined in their own file.
     images_height = 10,
     eval_sign_text = "│",
+    show_eval = true,
 }
 
 config.log = {

--- a/lua/smuggler/ui.lua
+++ b/lua/smuggler/ui.lua
@@ -94,17 +94,24 @@ function ui.create_user_commands()
 	})
 	vim.api.nvim_create_user_command("SmuggleHideEvaluated", function(_)
 		ui.hide_chunk_highlights(vim.api.nvim_get_current_buf())
+	    config.ui.show_eval = false 
+	end, {
+		desc = "Hide highlight around evaluated chunks, continues to track evaluated code which can be show with SmuggleShowEvaluated later",
+	})
+	vim.api.nvim_create_user_command("SmuggleDisableEvaluated", function(_)
+		ui.hide_chunk_highlights(vim.api.nvim_get_current_buf())
 	    ui.disable_autocommands(vim.api.nvim_get_current_buf())
+        run.buffers[vim.api.nvim_get_current_buf()].evaluated_chunks={}
 	    config.ui.show_eval = false
 	end, {
-		desc = "Hide highlight around evaluated chunks.",
+		desc = "Disable tracking of evaluated chunks and delete evaluated chunks info from buffer",
 	})
 	vim.api.nvim_create_user_command("SmuggleShowEvaluated", function(_)
 		ui.init_autocommands(vim.api.nvim_get_current_buf())
 	    config.ui.show_eval = true 
 	    ui.place_chunk_highlights(vim.api.nvim_get_current_buf())
 	end, {
-		desc = "Show highlight around evaluated chunks.",
+		desc = "Show highlight around evaluated chunks. Enables tracking of evaluated code if not enabled",
 	})
 	vim.api.nvim_create_user_command("SmuggleHideResults", function(_)
 		ui.hide_evaluation_results(vim.api.nvim_get_current_buf())

--- a/lua/smuggler/ui.lua
+++ b/lua/smuggler/ui.lua
@@ -451,18 +451,22 @@ function ui.hide_diagnostic_loclist()
 end
 
 function ui.init_autocommands(bufnbr)
-    run.buffers[bufnbr].aucommands[1] = vim.api.nvim_create_autocmd({ "TextChangedI" }, {
-        callback = function(args)
-            run.buffers[bufnbr].update_chunk_cursor_display_event.set()
-        end,
-        buffer = bufnbr,
-    })
-    run.buffers[bufnbr].aucommands[2] = vim.api.nvim_create_autocmd({ "TextChanged" }, {
-        callback = function(args)
-            run.buffers[bufnbr].update_chunk_mark_display_event.set()
-        end,
-        buffer = bufnbr,
-    })
+    if run.buffers[bufnbr].aucommands[1] == nil then
+        run.buffers[bufnbr].aucommands[1] = vim.api.nvim_create_autocmd({ "TextChangedI" }, {
+            callback = function(args)
+                run.buffers[bufnbr].update_chunk_cursor_display_event.set()
+            end,
+            buffer = bufnbr,
+        })
+    end
+    if run.buffers[bufnbr].aucommands[2] == nil then
+        run.buffers[bufnbr].aucommands[2] = vim.api.nvim_create_autocmd({ "TextChanged" }, {
+            callback = function(args)
+                run.buffers[bufnbr].update_chunk_mark_display_event.set()
+            end,
+            buffer = bufnbr,
+        })
+    end
 end
 
 function ui.disable_autocommands(bufnbr)
@@ -472,6 +476,7 @@ function ui.disable_autocommands(bufnbr)
     if run.buffers[bufnbr].aucommands[2]~=nil then 
         vim.api.nvim_del_autocmd(run.buffers[bufnbr].aucommands[2])
     end
+    run.buffers[bufnbr].aucommands = {}
 end
 
 function ui.init_buffer(bufnbr)


### PR DESCRIPTION
to address https://github.com/Klafyvel/nvim-smuggler/issues/44

1) SmuggleDisableEvaluated disables autocommands and disables any evaluated signcolumn from being shown. It also deletes all tracked information of any evaluated code.

2) SmuggleShowEvaluated enables autocommands and enables printing to the signcolumn and shows the evaluated code that has been currently tracked

3) SmuggleHideEvaluated hides the signcolumns only. evaluated code is still tracked and can be re-shown with SmuggleShowEvaluated. also unlike earlier where editing the buffer would show the evaluated code again now it does not show unitl SmuggleShowEvaluated is called again.