### PR TITLE
feat(quickfix): Display all stacktraces in the quickfix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,6 @@ Neo-Vim companion plugin for [REPLSmuggler.jl](https://github.com/klafyvel/REPLS
 
 [![asciicast](https://asciinema.org/a/W6RTJeVzRL3SvUIHfuauLGDF7.svg)](https://asciinema.org/a/W6RTJeVzRL3SvUIHfuauLGDF7)
 
-## Features
-
-- [x]  Send text to Julia REPL
-- [x]  Auto-detection of available REPL
-- [x]  Send multiple lines
-- [x]  Send range
-- [x]  Send text objects
-- [ ]  Dynamic choice of module for execution
-
-
 ## Installation
 
 Using rocks.nvim:
@@ -44,70 +34,7 @@ return {
 }
 ```
     
-## Configuration
-
-The plugin is initialized through its `setup` function, which takes a table as
-its sole argument. The options are the following (given with their default
-values): 
-```lua
-  {
-    ui = {
-        mappings = { -- set to false to disable all mappings.
-          smuggle = "<leader>cs", -- Mapping for Smuggle in normal mode.
-          smuggle_range = "<leader>cs", -- For SmuggleRange in visual mode.
-          smuggle_config = "<leader>ce", -- SmuggleConfig in normal mode.
-          smuggle_operator = "gcs", -- SmuggleOperator in normal mode.
-        },
-        evaluated_hl = "MoreMsg", -- highlight group for evaluated chunks.
-        invalidated_hl = "WarningMsg", -- highlight group for invalidated evaluated chunks.
-        result_line_length = 80, -- line length of displayed results.
-        result_hl_group = "DiagnosticVirtualTextInfo", -- highlight group used for results.
-        display_results = true, -- Display evaluation results.
-        display_images = true, -- Display images if `images.nvim` is present.
-        images_height = 10, -- Number of lines an image should occupy.
-        eval_sign_text = "│", -- Symbol in signcolumn to mark evaluated/invalidated.
-        show_eval = true, -- If set to false, do not attempt to track modifications in evaluated code chunks.
-    },
-    log = {
-        level = "warn", -- available: trace, debug, info, warn, error, fatal
-        use_file = false, -- output logs to `stdpath("data")/smuggler.log`, e.g. `~/.local/share/nvim/smuggler.log `
-        use_console = true, -- output logs to the console.
-    },
-    buffers = {
-        eval_by_blocks = false, -- Configure each new session eval by block attribute.
-        autoselect_single_socket=true, -- When true, skip socket selection dialog if there's only one choice possible.
-        showdir = vim.fs.dirname(vim.fn.tempname()),
-        iocontext = { -- Julia's IOContext
-        -- (https://docs.julialang.org/en/v1/base/io-network/#Base.IOContext-Tuple%7BIO,%20Pair%7D)
-        -- options to use.
-            compact = true,
-            limit = true,
-            displaysize = {10, 80},
-        },
-    },
-  }
-```
-
-If you use the `rocks.nvim` package manager, you can use the
-[`rocks-config.nvim`](https://github.com/nvim-neorocks/rocks-config.nvim) package to call `setup` in
-`.config/nvim/lua/plugins/smuggler.lua`: 
-```lua
-  require('smuggler').setup({ ... })
-```
-
-If you use the `lazy.nvim` package manager, you can provide the configuration
-directly with the installation: 
-```lua
-  {
-    "klafyvel/nvim-smuggler",
-    opts = {
-        ...
-    },
-    dependencies = { "nvim-neotest/nvim-nio" },
-  }
-```
-
-## Documentation
+## Configuration and Documentation
 
 See [`:help smuggler`](https://github.com/klafyvel/nvim-smuggler/blob/main/doc/smuggler.txt).
 

--- a/doc/smuggler.txt
+++ b/doc/smuggler.txt
@@ -20,9 +20,10 @@ CONTENTS                                                   *smuggler-contents*
   2. Lua API .............................................. |smuggler-lua-api|
   3. Mappings ............................................ |smuggler-mappings|
   4. Configuration .................................. |smuggler-configuration|
-  4. License .............................................. |smuggler-license|
-  5. Contributing .................................... |smuggler-contributing|
-  6. Credits .............................................. |smuggler-credits|
+  5. Quickfix list ....................................... |smuggler-quickfix|
+  6. License .............................................. |smuggler-license|
+  7. Contributing .................................... |smuggler-contributing|
+  8. Credits .............................................. |smuggler-credits|
 
 ==============================================================================
 USAGE                                                         *smuggler-usage*
@@ -75,14 +76,14 @@ also set the |quickfix| list and open the quickfix window.
   :SmuggleShowDiagnostics
                         Show smuggler's diagnostics.
 
-                                                         *:SmuggleHideLocList*
-  :SmuggleHideLocList
-                        Hide smuggler's diagnostics loclist.
+                                                         *:SmuggleHideQuickFix*
+  :SmuggleHideQuickFix
+                        Hide smuggler's diagnostics quickfix.
 
-                                                             *:SmuggleLocList*
-  :SmuggleLocList
-                        Show smuggler's diagnostics loclist.
-
+                                                             *:SmuggleQuickFix*
+  :SmuggleQuickFix
+                        Set the quickfix list to the diagnostics received by
+                        smuggler. See also |smuggler-quickfix|.
                                                        *:SmuggleHideEvaluated*
   :SmuggleHideEvaluated
                         Hide highlight around evaluated chunks. The plugin 
@@ -197,6 +198,11 @@ values): >
         images_height = 10, -- Number of lines an image should occupy.
         eval_sign_text = "│", -- Symbol in signcolumn to mark evaluated/invalidated , set to "" to disable
         show_eval = true, -- If set to false, do not attempt to track modifications in evaluated code chunks.
+        qf_skip_base = false, -- If true, do not show errors in `Base`.
+        qf_auto_refresh = false, -- If true, the quickfix list is refreshed each time an error is smuggled.
+        qf_auto_open = false, -- If true, the quickfix window is opened each time nvim-smuggler refreshes the quickfix window.
+        qf_custom_text = false, -- If true, the quickfix text will be altered to look like Julia REPL Exception printing.
+        qf_custom_display = false, -- If true, the quickfix window will be given an opinionated look (works with qf_custom_text).
     },
     log = {
         level = "warn", -- available: trace, debug, info, warn, error, fatal
@@ -233,6 +239,21 @@ directly with the installation: >
     dependencies = { "nvim-neotest/nvim-nio" },
   }
 >
+==============================================================================
+QUICKFIX LIST                                              *smuggler-quickfix*
+
+The |quickfix| list is a powerful tool to navigate between errors. You can
+populate the list manually using the |:SmuggleQuickFix|. However, if you are
+relying on the quickfix list, you can have it automatically populated when an
+error is received by setting the `qf_auto_refresh` and `qf_auto_open` options
+in the configuration.
+
+The default display of the quickfix list in NeoVim looks different from
+standard REPL errors. You can override this using the provided configuration
+options `qf_custom_text` and `qf_custom_display`.
+If you are unhappy with the highlighting provided you can set your own 
+highlights using the `qfJuliaLineNr`, `qfJuliaFunc`, and `qfJuliaPos` highlight groups.
+
 ==============================================================================
 LICENSE                                                     *smuggler-license*
 

--- a/lua/smuggler/buffers.lua
+++ b/lua/smuggler/buffers.lua
@@ -146,6 +146,9 @@ function M.buffer(bufnbr, force, settings)
                 break
             end
             ui.show_diagnostics(buffer.number)
+            if config.ui.qf_auto_refresh then
+                ui.set_diagnostic_quickfixlist(buffer.number, true)
+            end
             buffer.update_diagnostic_display_event.clear()
         end
     end)

--- a/lua/smuggler/config.lua
+++ b/lua/smuggler/config.lua
@@ -12,6 +12,11 @@ config.ui = {
     images_height = 10,
     eval_sign_text = "│",
     show_eval = true,
+    qf_skip_base = false,
+    qf_auto_refresh = true,
+    qf_auto_open = false,
+    qf_custom_text = false,
+    qf_custom_display = false,
 }
 
 config.log = {

--- a/lua/smuggler/protocol.lua
+++ b/lua/smuggler/protocol.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 -- SemVer protocol version compatibility
-M.PROTOCOL_VERSION = vim.version.parse("0.4.x")
+M.PROTOCOL_VERSION = vim.version.parse("0.5.x")
 
 local uv = vim.loop
 local nio = require("nio")


### PR DESCRIPTION
Fix #12 and #27.

BREAKING CHANGE: New protocol version is used.
BREAKING CHANGE: Using the quickfix list instead of the loclist. Commands were renamed.

With new configuration options enabled, the quickfix window can now look like this:
![image](https://github.com/user-attachments/assets/c50f1cc8-647a-4a96-87ad-dc25359c5ea6)