### PR TITLE
feat(configuration): Allow configuration of dynamic names for the socket.

### DIFF
--- a/doc/smuggler.txt
+++ b/doc/smuggler.txt
@@ -214,6 +214,10 @@ values): >
         autoselect_single_socket=true, -- When true, skip socket selection
         -- dialog if there's only one choice possible.
         showdir = vim.fs.dirname(vim.fn.tempname()),
+        -- either a string, a table of string, or a function that returns one
+        -- of the former. This is a list of sockets for nvim-smuggler to try to
+        -- connect to.
+        availablesockets = require("smuggler.utils").getavailablesockets,
         iocontext = { -- Julia's IOContext
         -- (https://docs.julialang.org/en/v1/base/io-network/#Base.IOContext-Tuple%7BIO,%20Pair%7D)
         -- options to use.

--- a/lua/smuggler/config.lua
+++ b/lua/smuggler/config.lua
@@ -34,6 +34,7 @@ config.buffers = {
         limit = true,
         displaysize = { 10, 80 },
     },
+    availablesockets = require("smuggler.utils").getavailablesockets,
 }
 -- End of default config
 

--- a/lua/smuggler/utils.lua
+++ b/lua/smuggler/utils.lua
@@ -1,0 +1,26 @@
+local M = {}
+
+local uv = vim.loop
+
+function M.socketsdir()
+    if vim.fn.has("mac") == 1 then
+        return vim.fn.expand("$HOME") .. "/Library/Application Support/lang.julia.REPLSmuggler/"
+    elseif vim.fn.has("unix") == 1 then
+        return "/run/user/" .. tostring(uv.getuid()) .. "/julia/replsmuggler/"
+    elseif vim.fn.has("win32") == 1 then
+        return "\\\\.\\pipe\\"
+    else
+        error("Unsupported platform.")
+    end
+end
+
+function M.getavailablesockets()
+    local directory = M.socketsdir()
+    local res = {}
+    for v in vim.fs.dir(directory) do
+        res[#res + 1] = directory .. v
+    end
+    return res
+end
+
+return M


### PR DESCRIPTION
Fix #8.

This should allow fancy configuration schemes. For example, dynamically generated names for the socket to have NeoVim open Julia in a tmux/kitty/whatever pane with a predictable socket name and immediately connect to it. I need it to enable functional tests of the plugin (they are coming!).